### PR TITLE
Add Rails version to created migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Or install it yourself as:
 
 ## Usage
 
-    usage: unschema [SCHEMA_FILE] [MIGRATIONS_DIR]
+    usage: unschema [SCHEMA_FILE] [MIGRATIONS_DIR] [RAILS_VERSION]
 
 ## TODO
 

--- a/bin/unschema
+++ b/bin/unschema
@@ -7,12 +7,13 @@ $LOAD_PATH.unshift File.dirname(__FILE__) + '/../lib'
 
 require 'unschema'
 
-if ARGV.size != 2
-  puts "usage: unschema [SCHEMA_FILE] [MIGRATIONS_DIR]"
+if ARGV.size != 3
+  puts "usage: unschema [SCHEMA_FILE] [MIGRATIONS_DIR] [RAILS_VERSION]"
   exit 1
 end
 schema_file = ARGV[0]
 migrations_path = ARGV[1]
+rails_version = ARGV[2]
 
 puts "Processing #{schema_file.inspect}"
-Unschema::Base.process!(schema_file, migrations_path, true)
+Unschema::Base.process!(schema_file, migrations_path, true, rails_version)

--- a/lib/unschema/base.rb
+++ b/lib/unschema/base.rb
@@ -1,5 +1,5 @@
 module Unschema
-  class Base < Struct.new(:schema_file, :migrations_path, :verbose)
+  class Base < Struct.new(:schema_file, :migrations_path, :verbose, :rails_version)
     def self.process!(*args)
       new(*args).process
     end
@@ -51,7 +51,7 @@ module Unschema
     def dump_table_calls(table_name, calls)
       file = File.join(migrations_path, "#{next_migration}_create_#{table_name}.rb")
       File.open(file, "w") do |f|
-        MigrationDumper.new(table_name, calls).dump_to(f)
+        MigrationDumper.new(table_name, calls, rails_version: rails_version).dump_to(f)
       end
     end
 

--- a/lib/unschema/migration_dumper.rb
+++ b/lib/unschema/migration_dumper.rb
@@ -1,12 +1,13 @@
 module Unschema
   class MigrationDumper
-    def initialize(table_name, calls)
+    def initialize(table_name, calls, rails_version:)
       @table_name = table_name
-      @calls      = calls
+      @calls = calls
+      @rails_version = rails_version
     end
 
     def dump_to(f)
-      f << "class Create#{table_name_camelcased} < ActiveRecord::Migration\n"
+      f << "class Create#{table_name_camelcased} < ActiveRecord::Migration[#{@rails_version}]\n"
       f << "  def change\n"
 
       @calls.each do |call|
@@ -38,17 +39,17 @@ module Unschema
     end
 
     def table_name_camelcased
-      @table_name.gsub(/^(\w)/){|s| s.upcase }.gsub(/(_\w)/) { |s| s[-1, 1].upcase }
+      @table_name.gsub(/^(\w)/) { |s| s.upcase }.gsub(/(_\w)/) { |s| s[-1, 1].upcase }
     end
 
     def stringify_call(call)
-      args    = stringify_args(call.args)
+      args = stringify_args(call.args)
       options = stringify_options(call.options) unless call.options.empty?
-      [ args, options ].compact.join(", ")
+      [args, options].compact.join(", ")
     end
 
     def stringify_args(args)
-      args.inspect.gsub(/^\[|\]$/,"")
+      args.inspect.gsub(/^\[|\]$/, "")
     end
 
     def stringify_options(options)

--- a/test/integration/end_to_end_test.rb
+++ b/test/integration/end_to_end_test.rb
@@ -8,12 +8,13 @@ class EndToEndTest < TestCase
   end
 
   def test_schema_to_migrations
-    Unschema::Base.process!(schema_file, migrations_path.to_s)
+    rails_version = "5.1"
+    Unschema::Base.process!(schema_file, migrations_path.to_s, true, rails_version)
 
-    assert_equal ["20130222131356_create_abc.rb", "20130222131357_create_table1.rb", "20130222131358_create_the_table2.rb"], Dir[migrations_path.join "*.rb"].map{|path| File.basename(path)}.sort
+    assert_equal ["20130222131356_create_abc.rb", "20130222131357_create_table1.rb", "20130222131358_create_the_table2.rb"], Dir[migrations_path.join "*.rb"].map { |path| File.basename(path) }.sort
 
     assert_migration "20130222131356_create_abc.rb", <<-MIGRATION
-      class CreateAbc < ActiveRecord::Migration
+      class CreateAbc < ActiveRecord::Migration[#{rails_version}]
         def change
           create_table "abc" do |t|
             t.string "defgh"
@@ -23,7 +24,7 @@ class EndToEndTest < TestCase
     MIGRATION
 
     assert_migration "20130222131357_create_table1.rb", <<-MIGRATION
-      class CreateTable1 < ActiveRecord::Migration
+      class CreateTable1 < ActiveRecord::Migration[#{rails_version}]
         def change
           create_table "table1", :force => true do |t|
             t.string "str"
@@ -38,7 +39,7 @@ class EndToEndTest < TestCase
     MIGRATION
 
     assert_migration "20130222131358_create_the_table2.rb", <<-MIGRATION
-      class CreateTheTable2 < ActiveRecord::Migration
+      class CreateTheTable2 < ActiveRecord::Migration[#{rails_version}]
         def change
           create_table "the_table2", :force => true do |t|
             t.date "date"

--- a/test/unit/migration_dumper_test.rb
+++ b/test/unit/migration_dumper_test.rb
@@ -3,18 +3,20 @@ require 'helper'
 
 class MigrationDumperTest < TestCase
   def test_without_calls
-    create_dumper
+    create_dumper(rails_version: "5.1")
 
-    assert_change <<-STR
+    inner = <<-STR
     STR
+    assert_change inner, rails_version: "5.1"
   end
 
   def test_create_table_call
     create_dumper \
       create_call(:create_table, "table", :force => true) { |t|
-        t.string  "uid", :limit => 32, :unique => true
+        t.string "uid", :limit => 32, :unique => true
         t.integer "amount"
-      }
+      },
+      rails_version: "5.1"
 
     assert_change <<-STR
       create_table "table", :force => true do |t|
@@ -27,7 +29,8 @@ class MigrationDumperTest < TestCase
   def test_index_call
     create_dumper \
       create_call(:add_index, "table", "uid", :unique => true),
-      create_call(:add_index, "table", %w[composite index])
+      create_call(:add_index, "table", %w[composite index]),
+      rails_version: "5.1"
 
     assert_change <<-STR
       add_index "table", "uid", :unique => true
@@ -37,17 +40,17 @@ class MigrationDumperTest < TestCase
 
   private
 
-  def create_dumper(*calls)
-    @dumper = Unschema::MigrationDumper.new("foo_bar", calls)
+  def create_dumper(*calls, rails_version:)
+    @dumper = Unschema::MigrationDumper.new("foo_bar", calls, rails_version: rails_version)
   end
 
   def create_call(name, *args, &block)
     Unschema::SchemaIntermediator::Call.new(name, *args, &block)
   end
 
-  def assert_change(inner)
+  def assert_change(inner, rails_version: "5.1")
     expect = <<-STR
-      class CreateFooBar < ActiveRecord::Migration
+      class CreateFooBar < ActiveRecord::Migration[#{rails_version}]
         def change
     STR
 


### PR DESCRIPTION
In Rails >= 5.1 you have to specify the Rails version in migrations:
  `class CreateTests < ActiveRecord::Migration[RAILS_VERSION]`

/cc @splattael 